### PR TITLE
Additions to allow the reversing of selected lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ All lines in the current text editor will be alphabetically sorted. If you speci
 #### Reverse Lines
 All lines in the current text editor are reversed. This means that the previously last line is the first line after the operation has finished. You can use this operation to toggle the sort order.
 
+#### Reverse Lines Selection
+All lines in the current selection are reversed. This means that the previously last line is the first line after the operation has finished. You can use this operation to toggle the sort order.
+
 #### Sort Lines by length
 I don't have a practical example for this operation. But all lines are sorted by length and the shortest line will be the first line. The functionality was added to test the sort operation.
 

--- a/main.js
+++ b/main.js
@@ -95,11 +95,11 @@ define(function (require, exports) {
         }
     }
 	
-	function handleReverseLinesSelection(){
-		   var editor = exports._getEditor(),
+	function handleReverseLinesSelection() {
+		var editor = exports._getEditor(),
             codemirror = editor._codeMirror;
             
-			if (editor) {
+		if (editor) {
             if (editor.lineCount() > 0) {
                 if (codemirror.somethingSelected()) {
 					var selection = codemirror.getSelection();
@@ -113,32 +113,17 @@ define(function (require, exports) {
                     }
 					
 					var allLines = selection.split("\n");
-					 var i;
+					var i;
 					for (i = 0; i < allLines.length / 2; i++) {
 						var index = allLines.length - 1 - i;
 						var tmp         = allLines[i];
 						allLines[i]     = allLines[index];
 						allLines[index] = tmp;
-					
 					}
 					codemirror.replaceSelection(allLines.join("\n") + (removedLastLineBreak ? "\n" : ""));
-					}
-				else {
-					var i; 
-					for (i = 0; i < allLines.length / 2; i++) { 
-					var index = allLines.length - 1 - i; 
-					var tmp         = allLines[i]; 
-					allLines[i]     = allLines[index]; 
-					allLines[index] = tmp; 
-
-				
-				}
-				codemirror.setValue(allLines.join("\n"));
 				}
 			}
-		
-		
-	}
+		}
 	}
 		
     

--- a/main.js
+++ b/main.js
@@ -94,8 +94,55 @@ define(function (require, exports) {
             }
         }
     }
+	
+	function handleReverseLinesSelection(){
+		   var editor = exports._getEditor(),
+            codemirror = editor._codeMirror;
+            
+			if (editor) {
+            if (editor.lineCount() > 0) {
+                if (codemirror.somethingSelected()) {
+					var selection = codemirror.getSelection();
+                    var removedLastLineBreak = false;
+					
+					// preserve the last line break, because the last fully selected line has
+                    // a line break at the end. We add this after the sort
+                    if (selection.lastIndexOf("\n") === (selection.length - 1)) {
+                        selection = selection.substr(0, selection.length - 1);
+                        removedLastLineBreak = true;
+                    }
+					
+					var allLines = selection.split("\n");
+					 var i;
+					for (i = 0; i < allLines.length / 2; i++) {
+						var index = allLines.length - 1 - i;
+						var tmp         = allLines[i];
+						allLines[i]     = allLines[index];
+						allLines[index] = tmp;
+					
+					}
+					codemirror.replaceSelection(allLines.join("\n") + (removedLastLineBreak ? "\n" : ""));
+					}
+				else {
+					var i; 
+					for (i = 0; i < allLines.length / 2; i++) { 
+					var index = allLines.length - 1 - i; 
+					var tmp         = allLines[i]; 
+					allLines[i]     = allLines[index]; 
+					allLines[index] = tmp; 
 
-    function handleReverseLines() {
+				
+				}
+				codemirror.setValue(allLines.join("\n"));
+				}
+			}
+		
+		
+	}
+	}
+		
+    
+	function handleReverseLines() {
         var codemirror = _getCodeMirror(),
             allLines = getLines(codemirror);
 
@@ -175,9 +222,11 @@ define(function (require, exports) {
     var COMMAND_SORTLINESBYLENGTH = "de.richter.brackets.extension.brackets-sort-text.sortLinesByLength";   // package-style naming to avoid collisions
     var COMMAND_SHUFFLELINES = "de.richter.brackets.extension.brackets-sort-text.shuffleLines";   // package-style naming to avoid collisions
     var COMMAND_UNIQUELINES = "de.richter.brackets.extension.brackets-sort-text.uniqueLines";   // package-style naming to avoid collisions
-
+	var COMMAND_REVERSELINESSELECTION = "de.richter.brackets.extension.brackets-sort-text.reverseLinesSelection";
+	
     CommandManager.register(Strings.SORT_LINES,             COMMAND_SORTLINES,         handleSortLines);
     CommandManager.register(Strings.REVERSE_LINES,          COMMAND_REVERSELINES,      handleReverseLines);
+	CommandManager.register(Strings.REVERSE_LINES_SELECTION,          COMMAND_REVERSELINESSELECTION,      handleReverseLinesSelection);
     CommandManager.register(Strings.SORT_LINES_BY_LENGTH,   COMMAND_SORTLINESBYLENGTH, handleSortByLength);
     CommandManager.register(Strings.SHUFFLE_LINES,          COMMAND_SHUFFLELINES,      handleShuffleLines);
     CommandManager.register(Strings.REMOVE_DUPLICATE_LINES, COMMAND_UNIQUELINES,       handleRemoveDuplicateLines);
@@ -187,6 +236,7 @@ define(function (require, exports) {
     if (menu) {
         menu.addMenuItem(COMMAND_SORTLINES,         [{key: "F7"}]);
         menu.addMenuItem(COMMAND_REVERSELINES,      [{key: "Shift-F7"}]);
+		menu.addMenuItem(COMMAND_REVERSELINESSELECTION,      [{key: "Shift-Ctrl-F7"}]);
         menu.addMenuItem(COMMAND_SORTLINESBYLENGTH, [{key: "Ctrl-F7"}]);
         menu.addMenuItem(COMMAND_SHUFFLELINES,      [{key: "Alt-F7"}]);
         menu.addMenuItem(COMMAND_UNIQUELINES,       [{key: "Ctrl-Alt-F7"}]);
@@ -195,6 +245,7 @@ define(function (require, exports) {
     // Public API
     exports.sortLines            = handleSortLines;
     exports.reverseLines         = handleReverseLines;
+	exports.reverseLinesSelection         = handleReverseLinesSelection;
     exports.sortLinesByLength    = handleSortByLength;
     exports.shuffleLines         = handleShuffleLines;
     exports.removeDuplicateLines = handleRemoveDuplicateLines;

--- a/nls/de/strings.js
+++ b/nls/de/strings.js
@@ -29,6 +29,7 @@
 define({
     "SORT_LINES"             : "Zeilen Sortieren",
     "REVERSE_LINES"          : "Zeilenreihenfolge umdrehen",
+	"REVERSE_LINES_SELECTION"          : "Reverse line selection",
     "SORT_LINES_BY_LENGTH"   : "Zeilen nach Länge sortieren",
     "SHUFFLE_LINES"          : "Zeilen durcheinander",
     "REMOVE_DUPLICATE_LINES" : "Doppelte Zeilen entfernen"

--- a/nls/root/strings.js
+++ b/nls/root/strings.js
@@ -29,6 +29,7 @@
 define({
     "SORT_LINES"             : "Sort Lines",
     "REVERSE_LINES"          : "Reverse Lines",
+	"REVERSE_LINES_SELECTION"          : "Reverse Lines Selection",
     "SORT_LINES_BY_LENGTH"   : "Sort Lines by length",
     "SHUFFLE_LINES"          : "Shuffle Lines",
     "REMOVE_DUPLICATE_LINES" : "Remove Duplicate Lines"


### PR DESCRIPTION
I've altered the code a bit to allow the reversing of the selection as opposed to the whole file. I essentially just copied your code for the sort selection function and added your reverse functionality to it. Hopefully it will be helpful for some. 

This doesn't work for non-consecutive lines of text.